### PR TITLE
add redhat/centos support

### DIFF
--- a/cookbooks/spamassassin/metadata.rb
+++ b/cookbooks/spamassassin/metadata.rb
@@ -7,6 +7,6 @@ version           "0.1.1"
 
 recipe "spamassassin", "Installs and configures spamassassin"
 
-%w{ debian ubuntu }.each do |os|
+%w{ debian ubuntu redhat centos }.each do |os|
   supports os
 end

--- a/cookbooks/spamassassin/recipes/default.rb
+++ b/cookbooks/spamassassin/recipes/default.rb
@@ -18,8 +18,12 @@
 # limitations under the License.
 #
 
-%w{ spamassassin razor pyzor spamc }.each do |pkg|
-  package pkg
+if platform_family?('rhel')
+    package "spamassassin"
+else
+  %w{ spamassassin razor pyzor spamc }.each do |pkg|
+    package pkg
+  end
 end
 
 service "spamassassin" do


### PR DESCRIPTION
Hello,

Added support for RedHat/Centos by only installing the packages available on these OS's, the others are not required.

Regards,
R